### PR TITLE
Fix typo in `type_synomym`

### DIFF
--- a/grammar/module.js
+++ b/grammar/module.js
@@ -127,7 +127,7 @@ module.exports = {
    */
   declaration: $ => choice(
     $.decl,
-    $.type_synomym,
+    $.type_synonym,
     $.kind_signature,
     $.type_family,
     $.type_instance,

--- a/grammar/type.js
+++ b/grammar/type.js
@@ -357,7 +357,7 @@ module.exports = {
   // type decl
   // ------------------------------------------------------------------------
 
-  type_synomym: $ => seq(
+  type_synonym: $ => seq(
     'type',
     $._type_head,
     '=',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1771,7 +1771,7 @@
         }
       ]
     },
-    "type_synomym": {
+    "type_synonym": {
       "type": "SEQ",
       "members": [
         {
@@ -6638,7 +6638,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "type_synomym"
+          "name": "type_synonym"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -228,7 +228,7 @@
         "named": true
       },
       {
-        "type": "type_synomym",
+        "type": "type_synonym",
         "named": true
       }
     ]
@@ -5756,7 +5756,7 @@
     "fields": {}
   },
   {
-    "type": "type_synomym",
+    "type": "type_synonym",
     "named": true,
     "fields": {
       "name": {

--- a/test/corpus/context.txt
+++ b/test/corpus/context.txt
@@ -182,7 +182,7 @@ type A = A a => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (apply
@@ -200,7 +200,7 @@ type A = (a A) a => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (apply
@@ -221,7 +221,7 @@ type A = (A :: A a -> A) a => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (apply
@@ -246,7 +246,7 @@ type A = A a => ∀ a . a *+* a => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (apply
@@ -272,7 +272,7 @@ type A = (A => a a) -> A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (function
         (parens

--- a/test/corpus/implicit.txt
+++ b/test/corpus/implicit.txt
@@ -8,7 +8,7 @@ type A = ?a :: A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (implicit_parameter
         (implicit_variable)
@@ -24,7 +24,7 @@ type A = (?a :: A)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (parens
         (implicit_parameter
@@ -41,7 +41,7 @@ type A = (?a :: Int :: Constraint)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (parens
         (signature
@@ -60,7 +60,7 @@ type A = (A => ?a :: A)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (parens
         (context
@@ -79,7 +79,7 @@ type A = (?a :: A.A, A)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (tuple
         (implicit_parameter
@@ -100,7 +100,7 @@ type A = (?a :: A.A, A)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (tuple
         (implicit_parameter
@@ -121,7 +121,7 @@ type A = (?a :: A) => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (parens
@@ -140,7 +140,7 @@ type A = ?a :: ∀ a . A a => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (implicit_parameter
         (implicit_variable)

--- a/test/corpus/prec.txt
+++ b/test/corpus/prec.txt
@@ -1187,17 +1187,17 @@ type (#?) = (#?)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (prefix_id
         (operator))
       (prefix_id
         (operator)))
-    (type_synomym
+    (type_synonym
       (prefix_id
         (operator))
       (prefix_id
         (operator)))
-    (type_synomym
+    (type_synonym
       (prefix_id
         (operator))
       (prefix_id
@@ -1218,7 +1218,7 @@ type A = (# a | a # b | c #)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_tuple
         (infix
@@ -1226,7 +1226,7 @@ type A = (# a | a # b | c #)
           (operator)
           (variable))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_tuple
         (variable)
@@ -1235,7 +1235,7 @@ type A = (# a | a # b | c #)
           (operator)
           (variable))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_tuple
         (variable)
@@ -1243,12 +1243,12 @@ type A = (# a | a # b | c #)
           (variable)
           (operator)
           (variable))))
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_sum
         (name)
         (name)))
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_sum
         (infix
@@ -1256,7 +1256,7 @@ type A = (# a | a # b | c #)
           (operator)
           (variable))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_sum
         (variable)
@@ -1676,7 +1676,7 @@ type A = A.A.A A.A.A A.A.+++ A.A.A A.A.A A.A.+++ A.A.A A.A.A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (apply

--- a/test/corpus/type.txt
+++ b/test/corpus/type.txt
@@ -10,10 +10,10 @@ type A = A A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (name))
-    (type_synomym
+    (type_synonym
       (name)
       (type_params
         (variable))
@@ -26,7 +26,7 @@ type A = A A
             (variable))
           (name))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (name)
@@ -42,7 +42,7 @@ type A = A A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (name)
@@ -61,22 +61,22 @@ type A = 'A.A.A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (constructor)))
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (constructor)))
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (qualified
           (module
             (module_id))
           (constructor))))
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (qualified
@@ -96,10 +96,10 @@ type A = [A a]
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (prefix_list))
-    (type_synomym
+    (type_synonym
       (name)
       (list
         (apply
@@ -120,20 +120,20 @@ type A = (A.A.->)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unit))
-    (type_synomym
+    (type_synonym
       (name)
       (prefix_tuple))
-    (type_synomym
+    (type_synonym
       (name)
       (prefix_tuple))
-    (type_synomym
+    (type_synonym
       (name)
       (prefix_id
         (operator)))
-    (type_synomym
+    (type_synonym
       (name)
       (prefix_id
         (qualified
@@ -152,7 +152,7 @@ type A = A ++ A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -169,7 +169,7 @@ type A = A :++ A ':++ A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -190,7 +190,7 @@ type A = A : A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -207,7 +207,7 @@ type A = A ': A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -225,7 +225,7 @@ type A = '[]
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (empty_list)))))
@@ -240,7 +240,7 @@ type A = [A a, 'A, a]
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (list
         (apply
@@ -261,7 +261,7 @@ type A = '[a]
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (list
@@ -271,7 +271,7 @@ type A = '[a]
           (promoted
             (constructor))
           (variable))))
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (list
@@ -287,7 +287,7 @@ type A = A A.A.:++ A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -308,7 +308,7 @@ type A = A ':++ A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -326,7 +326,7 @@ type A = A 'A.:++ A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -347,7 +347,7 @@ type A = A `A.A` A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -368,7 +368,7 @@ type A = '(A a, A)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (tuple
@@ -388,7 +388,7 @@ type A = '(,,,)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (promoted
         (prefix_tuple)))))
@@ -405,19 +405,19 @@ type A = ∀ a . (A a ~ A a) => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
         (operator)
         (name)))
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
         (operator)
         (name)))
-    (type_synomym
+    (type_synonym
       (name)
       (forall
         (quantified_variables
@@ -444,7 +444,7 @@ type A = a a ': a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (apply
@@ -464,7 +464,7 @@ type A = A :++ A A ': A (A A a) : '[] ':++ A `A.A` '[]
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -510,7 +510,7 @@ type A = A a a a ++ A a a a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (apply
@@ -540,11 +540,11 @@ type A = A (A "a")
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (literal
         (string)))
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (name)
@@ -564,7 +564,7 @@ type A = (++) a a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (apply
@@ -583,7 +583,7 @@ type A = A => A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (name)
@@ -599,7 +599,7 @@ type A = ∀ a . A a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (forall
         (quantified_variables
@@ -619,7 +619,7 @@ type A = forall a a . A a => [A]
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (forall
         (quantified_variables
@@ -628,7 +628,7 @@ type A = forall a a . A a => [A]
         (context
           (name)
           (name))))
-    (type_synomym
+    (type_synonym
       (name)
       (forall
         (quantified_variables
@@ -651,7 +651,7 @@ type (A a a) = A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (parens
         (name)
         (type_params
@@ -725,7 +725,7 @@ type A = a %m -> a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (linear_function
         (variable)
@@ -733,7 +733,7 @@ type A = a %m -> a
           (literal
             (integer)))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (linear_function
         (variable)
@@ -741,14 +741,14 @@ type A = a %m -> a
           (literal
             (integer)))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (linear_function
         (variable)
         (modifier
           (name))
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (linear_function
         (variable)
@@ -767,12 +767,12 @@ type A = A ⊸ A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (linear_function
         (name)
         (name)))
-    (type_synomym
+    (type_synonym
       (name)
       (linear_function
         (name)
@@ -789,10 +789,10 @@ type A = (##)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_unit))
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_unit))))
 
@@ -806,7 +806,7 @@ type A = (# a #)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_tuple
         (variable)))))
@@ -823,7 +823,7 @@ type A =
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_tuple
         (variable)))))
@@ -840,7 +840,7 @@ type A =
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_tuple
         (variable)))))
@@ -855,7 +855,7 @@ type A = (# A | A# #)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (unboxed_sum
         (name)
@@ -871,7 +871,7 @@ type A = (# ,,, #) @A @A A# A#
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (apply
@@ -896,7 +896,7 @@ type A = (# | | | #) @A @A A# A#
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (apply
@@ -909,7 +909,7 @@ type A = (# | | | #) @A @A A# A#
               (name)))
           (name))
         (name)))
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (apply
@@ -933,7 +933,7 @@ type A = A ⇒ a → a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (context
         (name)
@@ -951,7 +951,7 @@ type A = ★
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (star))))
 
@@ -966,7 +966,7 @@ type A = A @A A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (apply
@@ -977,7 +977,7 @@ type A = A @A A
           (kind_application
             (name)))
         (name)))
-    (type_synomym
+    (type_synonym
       (name)
       (apply
         (apply
@@ -996,7 +996,7 @@ type A = (∀ a . A (a :: A) => a :: A, A)
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (tuple
         (signature
@@ -1044,7 +1044,7 @@ type A = (A :: A) :: A
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (signature
         (parens
@@ -1063,7 +1063,7 @@ type A = (a :: (* -> *) -> *) -> a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (function
         (parens
@@ -1087,7 +1087,7 @@ type A = a -> $(a ''A) -> a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (function
         (variable)
@@ -1110,7 +1110,7 @@ type A = a -> [a|a|] -> a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (function
         (variable)
@@ -1131,7 +1131,7 @@ type A = ∀ {a} {a :: A} a . a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (forall
         (quantified_variables
@@ -1154,7 +1154,7 @@ type A = ∀ a (a :: A) {a :: A} -> forall a -> forall a . a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (forall_required
         (quantified_variables
@@ -1186,11 +1186,11 @@ type A = ∀ -> a
 
 (haskell
   (declarations
-    (type_synomym
+    (type_synonym
       (name)
       (forall
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (forall_required
         (variable)))))

--- a/test/corpus/varsym.txt
+++ b/test/corpus/varsym.txt
@@ -694,7 +694,7 @@ type A = a % a
               (module_id))
             (operator))
           (variable))))
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (variable)
@@ -911,18 +911,18 @@ a = (a *)
               (module_id))
             (operator))
           (variable))))
-    (type_synomym
+    (type_synonym
       (name)
       (function
         (star)
         (star)))
-    (type_synomym
+    (type_synonym
       (name)
       (parens
         (function
           (star)
           (star))))
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (name)
@@ -1539,7 +1539,7 @@ type A = a - 1
         (variable))
       (match
         (variable)))
-    (type_synomym
+    (type_synonym
       (name)
       (infix
         (variable)


### PR DESCRIPTION
From https://github.com/tree-sitter/tree-sitter-haskell/pull/145