### PR TITLE
Allow type family injectivity annotations after kind signatures

### DIFF
--- a/grammar/type.js
+++ b/grammar/type.js
@@ -404,14 +404,10 @@ module.exports = {
     field('determined', repeat1($.variable)),
   ),
 
-  _tyfam_inj: $ => seq(
-    $.type_family_result,
-    optional($.type_family_injectivity),
-  ),
-
   _tyfam: $ => seq(
     $._type_head,
-    optional(choice($._kind_annotation, $._tyfam_inj)),
+    optional(choice($._kind_annotation, $.type_family_result)),
+    optional($.type_family_injectivity),
   ),
 
   _tyfam_equations: $ => layout($, field('equation', alias($._type_instance, $.equation))),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1921,27 +1921,6 @@
         }
       ]
     },
-    "_tyfam_inj": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type_family_result"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_family_injectivity"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
     "_tyfam": {
       "type": "SEQ",
       "members": [
@@ -1961,9 +1940,21 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "_tyfam_inj"
+                  "name": "type_family_result"
                 }
               ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_family_injectivity"
             },
             {
               "type": "BLANK"

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,7 +18,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata TSLanguageMetadata;
 typedef struct TSLanguageMetadata {
   uint8_t major_version;
   uint8_t minor_version;

--- a/test/corpus/family.txt
+++ b/test/corpus/family.txt
@@ -419,6 +419,12 @@ type family A a = r
 type family A a = (r :: A) | r -> a where
   A a = a
 
+type family A a :: r | r -> a where
+  A a = a
+
+type family A a | a -> a where
+  A a = a
+
 --------------------------------------------------------------------------------
 
 (haskell
@@ -441,6 +447,33 @@ type family A a = (r :: A) | r -> a where
           (signature
             (variable)
             (name))))
+      (type_family_injectivity
+        (variable)
+        (variable))
+      (equations
+        (equation
+          (name)
+          (type_patterns
+            (variable))
+          (variable))))
+    (type_family
+      (name)
+      (type_params
+        (variable))
+      (variable)
+      (type_family_injectivity
+        (variable)
+        (variable))
+      (equations
+        (equation
+          (name)
+          (type_patterns
+            (variable))
+          (variable))))
+    (type_family
+      (name)
+      (type_params
+        (variable))
       (type_family_injectivity
         (variable)
         (variable))


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-haskell/issues/150