### PR TITLE
Recognize tabs as whitespace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 /src/parser.c -diff
 /src/grammar.json -diff
 /src/node-types.json -diff
+/hsc/src/grammar.json -diff
+/hsc/src/node-types.json -diff

--- a/grammar.js
+++ b/grammar.js
@@ -56,6 +56,7 @@ module.exports = grammar({
    */
   extras: $ => [
     /\p{Zs}/,
+    /\t/,
     /\n/,
     /\r/,
     $.cpp,

--- a/hsc/src/grammar.json
+++ b/hsc/src/grammar.json
@@ -12858,6 +12858,10 @@
     },
     {
       "type": "PATTERN",
+      "value": "\\t"
+    },
+    {
+      "type": "PATTERN",
       "value": "\\n"
     },
     {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -12857,6 +12857,10 @@
     },
     {
       "type": "PATTERN",
+      "value": "\\t"
+    },
+    {
+      "type": "PATTERN",
       "value": "\\n"
     },
     {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1422,6 +1422,10 @@ static void take_line(Env *env) {
   while (not_eof(env) && !is_newline(PEEK)) S_ADVANCE;
 }
 
+static bool is_space_char_or_tab(int32_t c) {
+  return c == '\t' || is_space_char(c);
+}
+
 static bool is_space_or_tab(int32_t c) {
   return c == ' ' || c == '\t';
 }
@@ -1450,9 +1454,9 @@ static void take_line_escaped_newline(Env *env) {
  * Return whether any characters were skipped.
  */
 static bool skip_space(Env *env) {
-  if (!is_space_char(PEEK)) return false;
+  if (!is_space_char_or_tab(PEEK)) return false;
   S_SKIP;
-  while(is_space_char(PEEK)) S_SKIP;
+  while(is_space_char_or_tab(PEEK)) S_SKIP;
   return true;
 }
 
@@ -1493,7 +1497,7 @@ static Space skip_whitespace(Env *env) {
  * return the index of the next character.
  */
 static uint32_t take_space_from(Env *env, uint32_t start) {
-  return advance_while(env, start, is_space_char);
+  return advance_while(env, start, is_space_char_or_tab);
 }
 
 /**
@@ -2464,7 +2468,7 @@ static Symbol comment_type_char(Env *env, bool line_comment, uint32_t i) {
   while (not_eof(env)) {
     int32_t c = peek(env, i++);
     if (c == '|' || c == '^') return HADDOCK;
-    else if (!is_space_char(c)) break;
+    else if (!is_space_char_or_tab(c)) break;
   }
   return COMMENT;
 }
@@ -2938,7 +2942,7 @@ static void newline_lookahead(Env *env, Newline *newline) {
         newline->indent += 8;
         break;
       default:
-        if (is_space_char(peek0(env))) {
+        if (is_space_char_or_tab(peek0(env))) {
           skip_over(env, 0);
           newline->indent++;
           break;

--- a/test/corpus/layout.txt
+++ b/test/corpus/layout.txt
@@ -3422,3 +3422,55 @@ a = do
               (variable)
               (variable)
               (variable))))))))
+
+================================================================================
+layout: case with tab
+================================================================================
+
+a = case a of
+  A	-> a
+
+--------------------------------------------------------------------------------
+
+(haskell
+  (declarations
+    (bind
+      (variable)
+      (match
+        (case
+          (variable)
+          (alternatives
+            (alternative
+              (constructor)
+              (match
+                (variable)))))))))
+
+================================================================================
+layout: do with tab
+================================================================================
+
+a = do
+  let a = a
+	|| a
+  a
+
+--------------------------------------------------------------------------------
+
+(haskell
+  (declarations
+    (bind
+      (variable)
+      (match
+        (do
+          (let
+            (local_binds
+              (bind
+                (variable)
+                (match
+                  (infix
+                    (variable)
+                    (operator)
+                    (variable))))))
+
+          (exp
+            (variable)))))))


### PR DESCRIPTION
Somehow `\p{Zs}` does not include tabs and the added test fails.

I'm aware that Haskell strongly encourages to avoid tabs and don't use them myself but somehow I ended up with a tab in my test case and was puzzled why it fails.